### PR TITLE
Fix: set only chart version as release tag/version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,10 @@ jobs:
             echo "should_release=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Read chart version
+        id: chart_version
+        run: echo "version=$(yq '.version' charts/immich/Chart.yaml)" >> $GITHUB_OUTPUT
+
       - name: run chart-releaser
         id: cr
         if: ${{ steps.version.outputs.should_release == 'true' }}
@@ -39,7 +43,8 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: true
           CR_SKIP_EXISTING: true
-          CR_RELEASE_TAG: "${{ steps.version.outputs.chart_version }}"
+          CR_RELEASE_NAME_TEMPLATE: "${{ steps.chart_version.outputs.version }}"
+
       - name: Login to GitHub Container Registry
         if: ${{ steps.version.outputs.should_release == 'true' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3


### PR DESCRIPTION
In this PR I want to address that we remove the prefix "immich-" from the release version.

Currently, in Draft since I can't test that this change will do the correct thing. I just tested it locally, and it works, see: https://github.com/tzabbi/immich-charts/releases

~~But currently waiting for an answer in this issue: https://github.com/helm/chart-releaser-action/pull/57~~

EDIT: should work see: https://github.com/helm/chart-releaser?tab=readme-ov-file#configuration